### PR TITLE
Make ClearCLBufferToRandomAccessibleIntervalConverter return 3D / 2D RAIs instead of 5D RAI

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/converters/implementations/ClearCLBufferToRandomAccessibleIntervalConverter.java
+++ b/src/main/java/net/haesleinhuepf/clij/converters/implementations/ClearCLBufferToRandomAccessibleIntervalConverter.java
@@ -31,13 +31,19 @@ public class ClearCLBufferToRandomAccessibleIntervalConverter extends AbstractCL
             throw new IllegalArgumentException("Wrong image size!");
         }
 
-        long[] dimensions = new long[]{
-                source.getWidth(),
-                source.getHeight(),
-                1,
-                source.getDepth(),
-                1
-        };
+        long[] dimensions;
+        if(source.getDepth() > 1) {
+            dimensions = new long[]{
+                    source.getWidth(),
+                    source.getHeight(),
+                    source.getDepth()
+            };
+        }else {
+            dimensions = new long[]{
+                    source.getWidth(),
+                    source.getHeight()
+            };
+        }
 
         // Todo: in case of large images, we might use PlanarImgs!
 


### PR DESCRIPTION
Currently, the Converter will always return 5D `RandomAccessibleInterval` even though a `ClearCLBuffer` does not have more than 3 dimensions:

`ClearCLBuffer` of size  `[10, 20, 30]` 
-> `RandomAccessibleInterval` of size `[10, 20, 1, 30, 1]`

This commit will make it do the following:

`ClearCLBuffer [10, 20, 30]` 
-> `RandomAccessibleInterval [10, 20, 30]`

It becomes an issue when converting a `RandomAccessibleInterval` to `ClearCLBuffer` and back because this would happen:

`RandomAccessibleInterval [10, 20, 30]`
-> `ClearCLBuffer [10, 20, 30]` 
-> `RandomAccessibleInterval [10, 20, 1, 30, 1]`


One can argue that the commit will remove singleton dimensions:
-> `RandomAccessibleInterval [10, 20, 1]`
-> `ClearCLBuffer [10, 20, 1]` 
-> `RandomAccessibleInterval [10, 20]`

A solution would be to always return a 3D RAI, but then there would be this minor issue:

`RandomAccessibleInterval [10, 20]`
-> `ClearCLBuffer [10, 20, 1]` 
-> `RandomAccessibleInterval [10, 20, 1]`