### PR TITLE
Bug fix: Several 2D functions not working (Rotation2D added)

### DIFF
--- a/src/main/java/net/haesleinhuepf/clij/kernels/math.cl
+++ b/src/main/java/net/haesleinhuepf/clij/kernels/math.cl
@@ -418,7 +418,6 @@ __kernel void minPixelwiseScalar_2d(DTYPE_IMAGE_IN_2D  src,
 }
 
 
-
 __kernel void power_2d(DTYPE_IMAGE_IN_2D  src,
                               DTYPE_IMAGE_OUT_2D  dst,
                               float exponent

--- a/src/main/java/net/haesleinhuepf/clij/utilities/AffineTransform.java
+++ b/src/main/java/net/haesleinhuepf/clij/utilities/AffineTransform.java
@@ -1,5 +1,6 @@
 package net.haesleinhuepf.clij.utilities;
 
+import net.imglib2.realtransform.AffineTransform2D;
 import net.imglib2.realtransform.AffineTransform3D;
 
 /**
@@ -19,4 +20,10 @@ public class AffineTransform {
         };
     }
 
+    public static float[] matrixToFloatArray2D(AffineTransform2D at) {
+        return new float[] {
+                (float) at.get(0,0), (float) at.get(0,1), (float) at.get(0,2),
+                (float) at.get(1,0), (float) at.get(1,1), (float) at.get(1,2),
+        };
+    }
 }

--- a/src/main/java/net/haesleinhuepf/clij/utilities/CLIJOps.java
+++ b/src/main/java/net/haesleinhuepf/clij/utilities/CLIJOps.java
@@ -1,14 +1,27 @@
 package net.haesleinhuepf.clij.utilities;
-
 import net.haesleinhuepf.clij.CLIJ;
 import net.haesleinhuepf.clij.kernels.Kernels;
+import ij.ImagePlus;
+import ij.process.AutoThresholder;
 import net.haesleinhuepf.clij.clearcl.ClearCLBuffer;
 import net.haesleinhuepf.clij.clearcl.ClearCLImage;
+import net.haesleinhuepf.clij.clearcl.enums.ImageChannelDataType;
+import net.haesleinhuepf.clij.coremem.enums.NativeTypeEnum;
 import net.haesleinhuepf.clij.CLIJ;
+import net.haesleinhuepf.clij.utilities.AffineTransform;
+import net.haesleinhuepf.clij.utilities.CLKernelExecutor;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.realtransform.AffineTransform2D;
 import net.imglib2.realtransform.AffineTransform3D;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+import java.nio.FloatBuffer;
+import java.util.HashMap;
+import static net.haesleinhuepf.clij.utilities.CLIJUtilities.*;
 // this is generated code. See src/test/java/net/haesleinhuepf/clij/codegenerator for details
 public class CLIJOps {
-   private final CLIJ clij;
+   private CLIJ clij;
    public CLIJOps(CLIJ clij) {
        this.clij = clij;
    }
@@ -44,20 +57,36 @@ public class CLIJOps {
         return Kernels.addImagesWeighted(clij, src, src1, dst, factor, factor1);
     }
 
-    public boolean affineTransform( ClearCLBuffer src,  ClearCLBuffer dst,  float[] matrix ) {
-        return Kernels.affineTransform(clij, src, dst, matrix);
+    public boolean affineTransform2D( ClearCLBuffer src,  ClearCLBuffer dst,  float[] matrix ) {
+        return Kernels.affineTransform2D(clij, src, dst, matrix);
     }
 
-    public boolean affineTransform( ClearCLBuffer src,  ClearCLBuffer dst,  AffineTransform3D at ) {
-        return Kernels.affineTransform(clij, src, dst, at);
+    public boolean affineTransform2D( ClearCLBuffer src,  ClearCLBuffer dst,  AffineTransform2D at ) {
+        return Kernels.affineTransform2D(clij, src, dst, at);
     }
 
-    public boolean affineTransform( ClearCLImage src,  ClearCLImage dst,  float[] matrix ) {
-        return Kernels.affineTransform(clij, src, dst, matrix);
+    public boolean affineTransform2D( ClearCLImage src,  ClearCLImage dst,  float[] matrix ) {
+        return Kernels.affineTransform2D(clij, src, dst, matrix);
     }
 
-    public boolean affineTransform( ClearCLImage src,  ClearCLImage dst,  AffineTransform3D at ) {
-        return Kernels.affineTransform(clij, src, dst, at);
+    public boolean affineTransform2D( ClearCLImage src,  ClearCLImage dst,  AffineTransform2D at ) {
+        return Kernels.affineTransform2D(clij, src, dst, at);
+    }
+
+    public boolean affineTransform3D( ClearCLBuffer src,  ClearCLBuffer dst,  float[] matrix ) {
+        return Kernels.affineTransform3D(clij, src, dst, matrix);
+    }
+
+    public boolean affineTransform3D( ClearCLBuffer src,  ClearCLBuffer dst,  AffineTransform3D at ) {
+        return Kernels.affineTransform3D(clij, src, dst, at);
+    }
+
+    public boolean affineTransform3D( ClearCLImage src,  ClearCLImage dst,  float[] matrix ) {
+        return Kernels.affineTransform3D(clij, src, dst, matrix);
+    }
+
+    public boolean affineTransform3D( ClearCLImage src,  ClearCLImage dst,  AffineTransform3D at ) {
+        return Kernels.affineTransform3D(clij, src, dst, at);
     }
 
     public boolean applyVectorfield( ClearCLImage src,  ClearCLImage vectorX,  ClearCLImage vectorY,  ClearCLImage dst ) {

--- a/src/test/java/net/haesleinhuepf/clij/test/AffineTransformTest.java
+++ b/src/test/java/net/haesleinhuepf/clij/test/AffineTransformTest.java
@@ -8,6 +8,7 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.realtransform.AffineTransform3D;
 import net.imglib2.type.numeric.real.FloatType;
+
 import org.junit.Test;
 
 import java.lang.reflect.Array;
@@ -52,7 +53,7 @@ public class AffineTransformTest {
         AffineTransform3D at = new AffineTransform3D();
         at.translate(4, 0, 0);
 
-        Kernels.affineTransform(clij, input, output, at);
+        Kernels.affineTransform3D(clij, input, output, at);
 
         TestUtilities.printBuffer(clij, output);
 
@@ -94,7 +95,7 @@ public class AffineTransformTest {
         AffineTransform3D at = new AffineTransform3D();
         at.translate(4, 0, 0);
 
-        Kernels.affineTransform(clij, input, output, at);
+        Kernels.affineTransform3D(clij, input, output, at);
 
         ClearCLBuffer bufferOutput = clij.convert(output, ClearCLBuffer.class);
         ClearCLBuffer referenceOutput = clij.convert(reference, ClearCLBuffer.class);

--- a/src/test/java/net/haesleinhuepf/clij/test/CrossCorrelationTest.java
+++ b/src/test/java/net/haesleinhuepf/clij/test/CrossCorrelationTest.java
@@ -143,7 +143,7 @@ public class CrossCorrelationTest {
         AffineTransform3D at = new AffineTransform3D();
         at.translate(0, 2, 0);
 
-        Kernels.affineTransform(clij, input, shifted, at);
+        Kernels.affineTransform3D(clij, input, shifted, at);
 
         // prepare cross-correlation analysis
         int meanRange = 5;


### PR DESCRIPTION
see Issue #32 (Rotate 2D image on GPU' not working on single plane images):
Black image when Rotate2D is applied to singel plane image.
At least Translate2D and Scale2D show same behaviour on GeForce GTX 1060